### PR TITLE
fix(tests): use arr size 1000 instead of 100

### DIFF
--- a/benchmarks/array/map.ts
+++ b/benchmarks/array/map.ts
@@ -40,7 +40,7 @@ bench(
   { name: '100 js - map', fn: () => jsMap(array, cbf) },
 );
 
-array = safeMap(Array(100).fill(0), add);
+array = safeMap(Array(1000).fill(0), add);
 bench(
   { name: '1000 hikidashi safe - map', fn: () => safeMap(array, cbf) },
   { name: '1000 hikidashi unsafe - map', fn: () => unsafeMap(array, cbf) },


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


This is a bug fix for map tests.

For now, this uses an array size of 100 instead of 1000 as documented for the final test.

I have fixed this behavior.

