### PR TITLE
feat(unsafe): add mmuleq and mdiveq, export matrix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "yarn test",
+            "name": "Run yarn test",
+            "request": "launch",
+            "type": "node-terminal",
+            "preLaunchTask": "npm: build"
+        }
+    ]
+}

--- a/src/unsafe.ts
+++ b/src/unsafe.ts
@@ -1,3 +1,4 @@
 export * from './unsafe/math';
 export * from './unsafe/util';
 export * from './unsafe/array';
+export * from './unsafe/matrix';

--- a/src/unsafe/matrix/index.ts
+++ b/src/unsafe/matrix/index.ts
@@ -1,0 +1,4 @@
+export { default as maddeq } from './maddeq';
+export { default as msubeq } from './msubeq';
+export { default as mmuleq } from './mmuleq';
+export { default as mdiveq } from './mdiveq';

--- a/src/unsafe/matrix/mdiveq.ts
+++ b/src/unsafe/matrix/mdiveq.ts
@@ -1,0 +1,22 @@
+import type { ArrayLike } from '@/shared/generics';
+
+/**
+ * Divides two arrays back into and *modifying the first array* as if a /= b.
+ *
+ * @remarks
+ *
+ * This implementation loops in reverse order.
+ * The mdiveq function should be used with caution due to its destructive nature.
+ * We implicitly assume that the second array contains at least as many elements as the first.
+ *
+ * @param a - The dividend, first input array-like to divide and modify.
+ * @param b - The divisor, second input array-like to divide.
+ *
+ * @returns typeof a - The modified input.
+ */
+const mdiveq = (a: ArrayLike, b: ArrayLike): typeof a => {
+  let i = a.length;
+  while (i--) a[i] /= b[i];
+  return a;
+};
+export default mdiveq;

--- a/src/unsafe/matrix/mmuleq.ts
+++ b/src/unsafe/matrix/mmuleq.ts
@@ -1,12 +1,12 @@
 import type { ArrayLike } from '@/shared/generics';
 
 /**
- * Subtracts two arrays back into and *modifying the first array* as if a -= b.
+ * Multiplies two arrays back into and *modifying the first array* as if a -= b.
  *
  * @remarks
  *
  * This implementation loops in reverse order.
- * The msubeq function should be used with caution due to its destructive nature.
+ * The mmuleq function should be used with caution due to its destructive nature.
  * We implicitly assume that the second array contains at least as many elements as the first.
  *
  * @param a - The minuend, first input array-like to subtract and modify.
@@ -14,9 +14,9 @@ import type { ArrayLike } from '@/shared/generics';
  *
  * @returns typeof a - The modified input.
  */
-const msubeq = (a: ArrayLike, b: ArrayLike): typeof a => {
+const mmuleq = (a: ArrayLike, b: ArrayLike): typeof a => {
   let i = a.length;
-  while (i--) a[i] -= b[i];
+  while (i--) a[i] *= b[i];
   return a;
 };
-export default msubeq;
+export default mmuleq;

--- a/src/unsafe/matrix/msubeq.ts
+++ b/src/unsafe/matrix/msubeq.ts
@@ -1,0 +1,22 @@
+import type { ArrayLike } from '@/shared/generics';
+
+/**
+ * Subtracts two arrays back into and *modifying the first array* as if a -= b.
+ *
+ * @remarks
+ *
+ * This implementation loops in reverse order.
+ * The maddeq function should be used with caution due to its destructive nature.
+ * We implicitly assume that the second array contains at least as many elements as the first.
+ *
+ * @param a - The minuend, first input array-like to subtract and modify.
+ * @param b - The subtrahend, second input array-like to subtract.
+ *
+ * @returns typeof a - The modified input.
+ */
+const msubeq = (a: ArrayLike, b: ArrayLike): typeof a => {
+  let i = a.length;
+  while (i--) a[i] -= b[i];
+  return a;
+};
+export default msubeq;

--- a/tests/unsafe/matrix/maddeq.test.ts
+++ b/tests/unsafe/matrix/maddeq.test.ts
@@ -1,0 +1,21 @@
+import a from '@/unsafe/matrix/maddeq';
+import { maddeq as a2 } from '@/unsafe';
+import { unsafe } from '@';
+
+describe.each([a, a2, unsafe.maddeq])('%# - unsafe maddeq', add => {
+  test('add empty arg values to throw', () => {
+    expect(add).toThrow(TypeError);
+  });
+
+  test('adds [11] + [22] to equal [33]', () => {
+    expect(add([11], [22])).toStrictEqual([33]);
+  });
+
+  test('adds [11, 22, 33] + [1, 2, 3] to equal [12, 24, 36]', () => {
+    expect(add([11, 22, 33], [1, 2, 3])).toStrictEqual([12, 24, 36]);
+  });
+
+  test("adds [11] + ['22'] to equal ['1122']", () => {
+    expect(add([11], ['22'])).toStrictEqual(['1122']);
+  });
+});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the mmuleq and mdiveq functions, exports matrix to the unsafe namespace, and fixes documentation. Also adds a matrix test base.


* **What is the current behavior?** (You can also link to an open issue here)
None.


* **What is the new behavior (if this is a feature change)?**
mmuleq acts as *= while mdiveq acts as /= just as the other matrix functions. Furthermore, unsafe.matrix has been exported and methods are query-able directly on the export object.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, the unsafe namespace has additional methods listed.


* **Other information**:
N/A